### PR TITLE
Fix/handle no prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ npm init adonisjs -- --pkg="yarn"
 
 ### Other options
 
-| Option            | Description                       |
-| ----------------- | --------------------------------- |
-| `--skip-install`  | Skip installing dependencies.     |
-| `--skip-git-init` | Skip initializing git repository. |
+| Option               | Description                               |
+|----------------------|-------------------------------------------|
+| `--skip-install`     | Skip installing dependencies.             |
+| `--skip-git-init`    | Skip initializing git repository.         |
+| `--no-skip-install`  | Install dependencies without prompt.      |
+| `--no-skip-git-init` | Initialize git repository without prompt. |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ npm init adonisjs -- --pkg="yarn"
 
 ### Other options
 
-| Option               | Description                               |
-|----------------------|-------------------------------------------|
-| `--skip-install`     | Skip installing dependencies.             |
-| `--skip-git-init`    | Skip initializing git repository.         |
-| `--no-skip-install`  | Install dependencies without prompt.      |
-| `--no-skip-git-init` | Initialize git repository without prompt. |
+| Option            | Description                       |
+|-------------------|-----------------------------------|
+| `--install`       | Install dependencies.             |
+| `--git-init`      | Initialize git repository.        |
+| `--no-install`    | Don't install dependencies.       |
+| `--no-git-init`   | Don't initialize git repository.  |
 
 ## Contributing
 

--- a/commands/main.ts
+++ b/commands/main.ts
@@ -56,13 +56,13 @@ export class CreateNewApp extends BaseCommand {
    * Skip packages installation
    */
   @flags.boolean({ description: 'Skip packages installation' })
-  declare skipInstall: boolean
+  declare skipInstall?: boolean
 
   /**
    * Skip git initialization
    */
   @flags.boolean({ description: 'Skip git initialization' })
-  declare skipGitInit: boolean
+  declare skipGitInit?: boolean
 
   /**
    * Package manager to use
@@ -131,10 +131,13 @@ export class CreateNewApp extends BaseCommand {
       return
     }
 
-    this.#shouldInstallDependencies = await this.prompt.confirm(
-      'Do you want to install dependencies?',
-      { hint: this.packageManager + ' will be used', default: true }
-    )
+    this.#shouldInstallDependencies =
+      this.skipInstall === false
+        ? true
+        : await this.prompt.confirm('Do you want to install dependencies?', {
+            hint: this.packageManager + ' will be used',
+            default: true,
+          })
 
     if (!this.#shouldInstallDependencies) {
       return
@@ -162,9 +165,12 @@ export class CreateNewApp extends BaseCommand {
       return
     }
 
-    const shouldInit = await this.prompt.confirm('Do you want to initialize a git repository?', {
-      default: true,
-    })
+    const shouldInit =
+      this.skipGitInit === false
+        ? true
+        : await this.prompt.confirm('Do you want to initialize a git repository?', {
+            default: true,
+          })
 
     if (!shouldInit) {
       return
@@ -269,6 +275,9 @@ export class CreateNewApp extends BaseCommand {
     if (!this.packageManager) {
       this.packageManager = detectPackageManager()?.name || 'npm'
     }
+
+    console.log('this.skipInstall', this.skipInstall)
+    console.log('this.skipGitInit', this.skipGitInit)
 
     this.#printTitle()
 

--- a/commands/main.ts
+++ b/commands/main.ts
@@ -55,14 +55,14 @@ export class CreateNewApp extends BaseCommand {
   /**
    * Skip packages installation
    */
-  @flags.boolean({ description: 'Skip packages installation' })
-  declare skipInstall?: boolean
+  @flags.boolean({ description: 'Packages installation' })
+  declare install?: boolean
 
   /**
    * Skip git initialization
    */
-  @flags.boolean({ description: 'Skip git initialization' })
-  declare skipGitInit?: boolean
+  @flags.boolean({ description: 'Git initialization' })
+  declare gitInit?: boolean
 
   /**
    * Package manager to use
@@ -127,17 +127,16 @@ export class CreateNewApp extends BaseCommand {
    * Install dependencies with the detected package manager
    */
   async #installDependencies() {
-    if (this.skipInstall) {
+    if (this.install === false) {
       return
     }
 
     this.#shouldInstallDependencies =
-      this.skipInstall === false
-        ? true
-        : await this.prompt.confirm('Do you want to install dependencies?', {
-            hint: this.packageManager + ' will be used',
-            default: true,
-          })
+      this.install ||
+      (await this.prompt.confirm('Do you want to install dependencies?', {
+        hint: this.packageManager + ' will be used',
+        default: true,
+      }))
 
     if (!this.#shouldInstallDependencies) {
       return
@@ -161,16 +160,15 @@ export class CreateNewApp extends BaseCommand {
    * Init git repository inside the destination directory
    */
   async #initGitRepo() {
-    if (this.skipGitInit) {
+    if (this.gitInit === false) {
       return
     }
 
     const shouldInit =
-      this.skipGitInit === false
-        ? true
-        : await this.prompt.confirm('Do you want to initialize a git repository?', {
-            default: true,
-          })
+      this.gitInit ||
+      (await this.prompt.confirm('Do you want to initialize a git repository?', {
+        default: true,
+      }))
 
     if (!shouldInit) {
       return

--- a/commands/main.ts
+++ b/commands/main.ts
@@ -276,9 +276,6 @@ export class CreateNewApp extends BaseCommand {
       this.packageManager = detectPackageManager()?.name || 'npm'
     }
 
-    console.log('this.skipInstall', this.skipInstall)
-    console.log('this.skipGitInit', this.skipGitInit)
-
     this.#printTitle()
 
     await this.#setDestination()

--- a/tests/install_adonis.spec.ts
+++ b/tests/install_adonis.spec.ts
@@ -207,4 +207,25 @@ test.group('Create new app', (group) => {
     await command.exec()
     await assert.fileNotExists('foo/README.md')
   }).disableTimeout()
+
+  test('no skip install and no skip git init', async ({ assert, fs }) => {
+    const command = await kernel.create(CreateNewApp, [
+      join(fs.basePath, 'foo'),
+      '--pkg="npm"',
+      '--no-skip-install',
+      '--no-skip-git-init',
+      '--kit="github:adonisjs/slim-starter-kit"',
+    ])
+
+    assert.isFalse(command.skipInstall)
+    assert.isFalse(command.skipGitInit)
+
+    await command.exec()
+
+    const result = await execa('node', ['ace', '--help'], { cwd: join(fs.basePath, 'foo') })
+
+    assert.deepEqual(result.exitCode, 0)
+    assert.deepInclude(result.stdout, 'View list of available commands')
+    await assert.fileExists('foo/package.json')
+  })
 })

--- a/tests/install_adonis.spec.ts
+++ b/tests/install_adonis.spec.ts
@@ -25,8 +25,8 @@ test.group('Create new app', (group) => {
   test('clone template to destination', async ({ assert, fs }) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
-      '--skip-install',
-      '--skip-git-init',
+      '--no-install',
+      '--no-git-init',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -38,8 +38,8 @@ test.group('Create new app', (group) => {
 
   test('prompt for destination when not provided', async ({ assert }) => {
     const command = await kernel.create(CreateNewApp, [
-      '--skip-install',
-      '--skip-git-init',
+      '--no-install',
+      '--no-git-init',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -55,8 +55,8 @@ test.group('Create new app', (group) => {
 
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
-      '--skip-install',
-      '--skip-git-init',
+      '--no-install',
+      '--no-git-init',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -80,7 +80,7 @@ test.group('Create new app', (group) => {
 
       const command = await kernel.create(CreateNewApp, [
         join(fs.basePath, 'foo'),
-        '--skip-git-init',
+        '--no-git-init',
         '--kit="github:samuelmarina/is-even"',
       ])
       command.prompt.trap('Do you want to install dependencies?').replyWith(true)
@@ -95,8 +95,8 @@ test.group('Create new app', (group) => {
   test('do not install dependencies', async ({ assert, fs }) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
-      '--skip-install',
-      '--skip-git-init',
+      '--no-install',
+      '--no-git-init',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -105,10 +105,10 @@ test.group('Create new app', (group) => {
     await assert.fileNotExists(`foo/package-lock.json`)
   })
 
-  test('initialize git repo', async ({ assert, fs }) => {
+  test('prompt for initialize git repo', async ({ assert, fs }) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
-      '--skip-install',
+      '--no-install',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -122,8 +122,8 @@ test.group('Create new app', (group) => {
   test('do not initialize git repo', async ({ assert, fs }) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
-      '--skip-install',
-      '--skip-git-init',
+      '--no-install',
+      '--no-git-init',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -136,7 +136,7 @@ test.group('Create new app', (group) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
       '--pkg="yarn"',
-      '--skip-git-init',
+      '--no-git-init',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -208,24 +208,31 @@ test.group('Create new app', (group) => {
     await assert.fileNotExists('foo/README.md')
   }).disableTimeout()
 
-  test('no skip install and no skip git init', async ({ assert, fs }) => {
+  test('install dependencies without prompt', async ({ assert, fs }) => {
+    process.env.npm_config_user_agent = 'npm/7.0.0 node/v15.0.0 darwin x64'
+
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
-      '--pkg="npm"',
-      '--no-skip-install',
-      '--no-skip-git-init',
-      '--kit="github:adonisjs/slim-starter-kit"',
+      '--install',
+      '--no-git-init',
+      '--kit="github:samuelmarina/is-even"',
     ])
-
-    assert.isFalse(command.skipInstall)
-    assert.isFalse(command.skipGitInit)
 
     await command.exec()
 
-    const result = await execa('node', ['ace', '--help'], { cwd: join(fs.basePath, 'foo') })
+    await assert.dirExists(`foo/node_modules`)
+  })
 
-    assert.deepEqual(result.exitCode, 0)
-    assert.deepInclude(result.stdout, 'View list of available commands')
-    await assert.fileExists('foo/package.json')
+  test('initialize git repository without prompt', async ({ assert, fs }) => {
+    const command = await kernel.create(CreateNewApp, [
+      join(fs.basePath, 'foo'),
+      '--no-install',
+      '--git-init',
+      '--kit="github:samuelmarina/is-even"',
+    ])
+
+    await command.exec()
+
+    await assert.dirExists(`foo/.git`)
   })
 })

--- a/tests/install_adonis.spec.ts
+++ b/tests/install_adonis.spec.ts
@@ -208,20 +208,27 @@ test.group('Create new app', (group) => {
     await assert.fileNotExists('foo/README.md')
   }).disableTimeout()
 
-  test('install dependencies without prompt', async ({ assert, fs }) => {
-    process.env.npm_config_user_agent = 'npm/7.0.0 node/v15.0.0 darwin x64'
-
-    const command = await kernel.create(CreateNewApp, [
-      join(fs.basePath, 'foo'),
-      '--install',
-      '--no-git-init',
-      '--kit="github:samuelmarina/is-even"',
+  test('install dependencies without prompt')
+    .with([
+      { agent: 'npm/7.0.0 node/v15.0.0 darwin x64', lockFile: 'package-lock.json' },
+      { agent: 'pnpm/5.0.0 node/v15.0.0 darwin x64', lockFile: 'pnpm-lock.yaml' },
+      { agent: 'yarn/1.22.5 npm/? node/v15.0.0 darwin x64', lockFile: 'yarn.lock' },
     ])
+    .run(async ({ assert, fs }, { agent, lockFile }) => {
+      process.env.npm_config_user_agent = agent
 
-    await command.exec()
+      const command = await kernel.create(CreateNewApp, [
+        join(fs.basePath, 'foo'),
+        '--install',
+        '--no-git-init',
+        '--kit="github:samuelmarina/is-even"',
+      ])
 
-    await assert.dirExists(`foo/node_modules`)
-  })
+      await command.exec()
+
+      await assert.fileExists(`foo/${lockFile}`)
+      process.env.npm_config_user_agent = undefined
+    })
 
   test('initialize git repository without prompt', async ({ assert, fs }) => {
     const command = await kernel.create(CreateNewApp, [


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

https://github.com/adonisjs/road-to-v6/discussions/39

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Before the change, create-adonisjs was not handling `--no-` prefix on boolean flags, not allowing to force install and forge git init without prompt.

I'm working on a JetBrains plugin for Adonis and I would like to use officially supported `create-adonis` tool to initialize project.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
