### PR TITLE
Add prompt to select `Database` and `Auth guard`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,22 @@ We are trying to detect the package manager used by your project. However, if yo
 npm init adonisjs -- --pkg="yarn"
 ```
 
-### `--auth-guard` (Default: session)
+### `--auth-guard` (Default: Triggers prompt for selection)
 
 Specify a custom auth guard to use when using the `api` stater kit. One of the following options are allowed
 
-- `session` (Default)
+- `session`
 - `access_tokens`
 
 ```sh
 npm init adonisjs -- --kit="api" --auth-guard="access_tokens"
 ```
 
-### `--db` (Default: sqlite)
+### `--db` (Default: Triggers prompt for selection)
 
 Specify the database dialect to configure with Lucid. One of the following options are allowd.
 
-- `sqlite` (Default)
+- `sqlite`
 - `mysql`
 - `mssql`
 - `postgres`

--- a/commands/main.ts
+++ b/commands/main.ts
@@ -95,7 +95,7 @@ export class CreateNewApp extends BaseCommand {
   declare db?: string
 
   /**
-   * Auth guard for auth package. Defaults to "session"
+   * Auth guard for auth package.
    */
   @flags.string({
     description: 'Define the authentication guard for the Auth package',
@@ -204,11 +204,11 @@ export class CreateNewApp extends BaseCommand {
       /**
        * Display prompt when "db" flag is not used.
        */
-      const template = await this.prompt.choice(
+      const database = await this.prompt.choice(
         'Select the database driver you want to use',
         databases
       )
-      this.db = databases.find((t) => t.name === template)!.alias
+      this.db = databases.find((t) => t.name === database)!.alias
     }
   }
 

--- a/src/auth_guards.ts
+++ b/src/auth_guards.ts
@@ -1,0 +1,29 @@
+/*
+ * create-adonisjs
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * List of first party authentication guards
+ */
+export const authGuards = [
+  {
+    name: 'Session',
+    alias: 'session',
+    hint: 'Authenticate users using cookies and session.',
+  },
+  {
+    name: 'Access Token',
+    alias: 'access_tokens',
+    hint: 'Authenticate clients using tokens.',
+  },
+  {
+    name: 'Skip',
+    alias: undefined,
+    hint: 'I want to configures guards by myself.',
+  },
+]

--- a/src/databases.ts
+++ b/src/databases.ts
@@ -28,7 +28,7 @@ export const databases = [
     alias: 'mssql',
   },
   {
-    name: 'Do not initial database',
+    name: 'Skip',
     hint: 'I want to configures the Lucid package by myself.',
     alias: undefined,
   },

--- a/src/databases.ts
+++ b/src/databases.ts
@@ -1,0 +1,35 @@
+/*
+ * create-adonisjs
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * List of first party databases (lucid)
+ */
+export const databases = [
+  {
+    name: 'SQLite',
+    alias: 'sqlite',
+  },
+  {
+    name: 'MySQL / MariaDB',
+    alias: 'mysql',
+  },
+  {
+    name: 'PostgreSQL',
+    alias: 'postgres',
+  },
+  {
+    name: 'Microsoft SQL Server',
+    alias: 'mssql',
+  },
+  {
+    name: 'Do not initial database',
+    hint: 'I want to configures the Lucid package by myself.',
+    alias: undefined,
+  },
+]

--- a/tests/install_adonis.spec.ts
+++ b/tests/install_adonis.spec.ts
@@ -100,6 +100,8 @@ test.group('Create new app', (group) => {
 
     assert.deepEqual(result.exitCode, 0)
     assert.deepInclude(result.stdout, 'View list of available commands')
+
+    await assert.fileExists('foo/config/auth.ts')
   })
 
   test('prompt for database driver when not pre-defined and selected api/web kit', async ({
@@ -123,6 +125,8 @@ test.group('Create new app', (group) => {
 
     assert.deepEqual(result.exitCode, 0)
     assert.deepInclude(result.stdout, 'View list of available commands')
+
+    await assert.fileExists('foo/config/database.ts')
   })
 
   test('prompt for install dependencies when --install flag is not used', async ({

--- a/tests/install_adonis.spec.ts
+++ b/tests/install_adonis.spec.ts
@@ -30,6 +30,8 @@ test.group('Create new app', (group) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
       '--no-install',
+      '--db=sqlite',
+      '--auth-guard=session',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -43,6 +45,8 @@ test.group('Create new app', (group) => {
   test('prompt for destination when not provided', async ({ assert }) => {
     const command = await kernel.create(CreateNewApp, [
       '--no-install',
+      '--db=sqlite',
+      '--auth-guard=session',
       '--kit="github:samuelmarina/is-even"',
     ])
 
@@ -59,10 +63,57 @@ test.group('Create new app', (group) => {
       join(fs.basePath, 'foo'),
       '--pkg="npm"',
       '--install',
+      // not provide `--db` and `--auth-guard` to test that it will not prompt for slim kit
     ])
 
     command.verbose = VERBOSE
     command.prompt.trap('Which starter kit would you like to use?').chooseOption(0)
+
+    await command.exec()
+
+    const result = await execa('node', ['ace', '--help'], { cwd: join(fs.basePath, 'foo') })
+
+    assert.deepEqual(result.exitCode, 0)
+    assert.deepInclude(result.stdout, 'View list of available commands')
+  })
+
+  test('prompt for auth guard when not pre-defined and selected api/web kit', async ({
+    assert,
+    fs,
+  }) => {
+    const command = await kernel.create(CreateNewApp, [
+      join(fs.basePath, 'foo'),
+      '--pkg="npm"',
+      '-K=web',
+      '--db=sqlite',
+      '--install',
+    ])
+
+    command.verbose = VERBOSE
+    command.prompt.trap('Select the authentication guard you want to use').chooseOption(1)
+
+    await command.exec()
+
+    const result = await execa('node', ['ace', '--help'], { cwd: join(fs.basePath, 'foo') })
+
+    assert.deepEqual(result.exitCode, 0)
+    assert.deepInclude(result.stdout, 'View list of available commands')
+  })
+
+  test('prompt for database driver when not pre-defined and selected api/web kit', async ({
+    assert,
+    fs,
+  }) => {
+    const command = await kernel.create(CreateNewApp, [
+      join(fs.basePath, 'foo'),
+      '--pkg="npm"',
+      '-K=api',
+      '--auth-guard=session',
+      '--install',
+    ])
+
+    command.verbose = VERBOSE
+    command.prompt.trap('Select the database driver you want to use').chooseOption(1)
 
     await command.exec()
 
@@ -79,6 +130,8 @@ test.group('Create new app', (group) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
       '--pkg="npm"',
+      '--db=sqlite',
+      '--auth-guard=session',
       '-K=slim',
     ])
 
@@ -124,6 +177,8 @@ test.group('Create new app', (group) => {
       const command = await kernel.create(CreateNewApp, [
         join(fs.basePath, 'foo'),
         '--install',
+        '--db=sqlite',
+        '--auth-guard=session',
         '--kit="github:samuelmarina/is-even"',
       ])
 
@@ -138,6 +193,8 @@ test.group('Create new app', (group) => {
   test('do not install dependencies when --no-install flag is provided', async ({ assert, fs }) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
+      '--db=sqlite',
+      '--auth-guard=session',
       '--no-install',
       '--kit="github:samuelmarina/is-even"',
     ])
@@ -166,6 +223,8 @@ test.group('Create new app', (group) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
       '--pkg="yarn"',
+      '--db=sqlite',
+      '--auth-guard=session',
       '--install',
       '--kit="github:samuelmarina/is-even"',
     ])
@@ -255,6 +314,8 @@ test.group('Configure | Web starter kit', (group) => {
     const command = await kernel.create(CreateNewApp, [
       join(fs.basePath, 'foo'),
       '--pkg="npm"',
+      '--db=sqlite',
+      '--auth-guard=session',
       '--install',
       '-K=web',
     ])
@@ -289,6 +350,7 @@ test.group('Configure | Web starter kit', (group) => {
       '--pkg="npm"',
       '--install',
       '-K=web',
+      '--auth-guard=session',
       '--db=postgres',
     ])
 
@@ -313,6 +375,8 @@ test.group('Configure | API starter kit', (group) => {
       '--pkg="npm"',
       '--install',
       '-K=api',
+      '--db=sqlite',
+      '--auth-guard=session',
     ])
 
     command.verbose = VERBOSE
@@ -354,6 +418,7 @@ test.group('Configure | API starter kit', (group) => {
       '--pkg="npm"',
       '--install',
       '-K=api',
+      '--db=sqlite',
       '--auth-guard=access_tokens',
     ])
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
https://discord.com/channels/423256550564691970/1199775897448882286

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
- Add prompt to select `Database Driver` and `Auth Guard` only for `Web Starter Kit` and `API Starter Kit` and if it not specified in CLI arguments.
- Remove default value of `--db` and `--auth-guard` and it will prompt to select instead
- Add a warning message if they select to not install dependencies they will need to configure both guards and db manually
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

PS. Please, excuse my grammar. If there are any typos please notify me, I will fix it asap. :)