### PR TITLE
Feat/inertia

### DIFF
--- a/src/inertia_adapters.ts
+++ b/src/inertia_adapters.ts
@@ -1,0 +1,35 @@
+/*
+ * create-adonisjs
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * List of adapters for configuring Inertia
+ */
+export const adapters = [
+  {
+    name: 'Vue 3',
+    alias: 'vue',
+  },
+  {
+    name: 'React',
+    alias: 'react',
+  },
+  {
+    name: 'Svelte',
+    alias: 'svelte',
+  },
+  {
+    name: 'Solid.js',
+    alias: 'solid',
+  },
+  {
+    name: 'Skip',
+    hint: 'I want to configure Inertia by myself.',
+    alias: undefined,
+  },
+]

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -29,4 +29,10 @@ export const templates = [
     hint: 'AdonisJS app tailored for creating JSON APIs',
     source: 'github:adonisjs/api-starter-kit',
   },
+  {
+    name: 'Inertia Starter Kit',
+    alias: 'inertia',
+    hint: 'AdonisJS app with Inertia.JS and your favorite frontend framework',
+    source: 'github:adonisjs/inertia-starter-kit',
+  },
 ]

--- a/tests/install_adonis.spec.ts
+++ b/tests/install_adonis.spec.ts
@@ -510,3 +510,55 @@ test.group('Configure | API starter kit', (group) => {
     await assert.fileNotContains('foo/package.json', ['@adonisjs/session'])
   })
 })
+
+test.group('Configure | Inertia Starter Kit', (group) => {
+  group.each.disableTimeout()
+
+  test('configure lucid/auth/inertia when using inertia starter kit', async ({ assert, fs }) => {
+    const command = await kernel.create(CreateNewApp, [
+      join(fs.basePath, 'foo'),
+      '--pkg="npm"',
+      '--install',
+      '-K=inertia',
+      '--db=sqlite',
+      '--auth-guard=session',
+      '--ssr',
+      '--adapter=solid',
+    ])
+
+    command.verbose = VERBOSE
+    await command.exec()
+
+    const result = await execa('node', ['ace', '--help'], { cwd: join(fs.basePath, 'foo') })
+    assert.deepEqual(result.exitCode, 0)
+    assert.deepInclude(result.stdout, 'View list of available commands')
+
+    await assert.fileContains('foo/adonisrc.ts', [
+      `() => import('@adonisjs/lucid/database_provider')`,
+      `() => import('@adonisjs/auth/auth_provider')`,
+      `() => import('@adonisjs/session/session_provider')`,
+      `() => import('@adonisjs/lucid/commands')`,
+    ])
+    await assert.fileContains('foo/start/kernel.ts', [
+      `() => import('@adonisjs/session/session_middleware')`,
+    ])
+    await assert.fileExists('foo/config/database.ts')
+    await assert.fileExists('foo/config/auth.ts')
+    await assert.fileExists('foo/resources/app.tsx')
+    await assert.fileExists('foo/resources/ssr.tsx')
+    await assert.fileExists('foo/config/inertia.ts')
+    await assert.fileExists('foo/config/session.ts')
+    await assert.fileExists('foo/app/models/user.ts')
+    await assert.fileContains('foo/package.json', [
+      '@adonisjs/session',
+      '@adonisjs/lucid',
+      '@adonisjs/inertia',
+      'solid-js',
+      'vite-plugin-solid',
+      '@adonisjs/auth',
+      'luxon',
+      '@types/luxon',
+      'better-sqlite',
+    ])
+  })
+})


### PR DESCRIPTION
Support for starter-kit-inertia https://github.com/adonisjs/inertia-starter-kit 

Lets forget about using `configure.ts` at the root of respective starter kits for now. Too complicated and time-consuming to develop atm. we can see that later. This PR should do the trick for now

Usage is exactly the same as web-starter-kit, except that you have two extra flags 

You can pass the `--adapter` flag to configure the frontend adapter. Available options are `react`, `vue`, `solid`, and `svelte`.

```sh
npm init adonisjs -- -K=inertia --adapter=react
```

You can also pass the `--ssr` or `--no-ssr` flag to enable or disable server-side rendering.

```sh
npm init adonisjs -- -K=inertia --ssr
```