### PR TITLE
fix: starter kit - inertia - remove redundant `db` dependency

### DIFF
--- a/commands/main.ts
+++ b/commands/main.ts
@@ -313,10 +313,9 @@ export class CreateNewApp extends BaseCommand {
    */
   async #removeLockFile() {
     await Promise.allSettled([
-      unlink(join(this.destination, 'bun.lockb')),
       unlink(join(this.destination, 'package-lock.json')),
-      unlink(join(this.destination, 'pnpm-lock.yaml')),
       unlink(join(this.destination, 'yarn.lock')),
+      unlink(join(this.destination, 'pnpm-lock.yaml')),
     ])
   }
 

--- a/commands/main.ts
+++ b/commands/main.ts
@@ -282,7 +282,7 @@ export class CreateNewApp extends BaseCommand {
         `Do you want us to install dependencies using "${this.packageManager}"?`,
         {
           default: true,
-          hint: "(If not, you'll need to configure guards and database manually)",
+          hint: "(If not, you'll need to configure guards, database and inertia manually)",
         }
       )
     }
@@ -313,9 +313,10 @@ export class CreateNewApp extends BaseCommand {
    */
   async #removeLockFile() {
     await Promise.allSettled([
+      unlink(join(this.destination, 'bun.lockb')),
       unlink(join(this.destination, 'package-lock.json')),
-      unlink(join(this.destination, 'yarn.lock')),
       unlink(join(this.destination, 'pnpm-lock.yaml')),
+      unlink(join(this.destination, 'yarn.lock')),
     ])
   }
 
@@ -481,8 +482,7 @@ export class CreateNewApp extends BaseCommand {
     /**
      * Configure inertia when using our inertia starter kit
      */
-    const configureInertia =
-      this.kit === INERTIA_STARTER_KIT && this.db !== undefined && this.install !== false
+    const configureInertia = this.kit === INERTIA_STARTER_KIT && this.install !== false
 
     tasks
       .add('Download starter kit', async (task) => {


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When installing with `Inertia` starter kit there is no need for `db` to be configured, yet the CLI enforces this check leading to UX confusion when using the CLI, since the users are prompted to configure their installation, there is no place to mention that when selecting `inertia` the user **must** also select a `db` driver in order for `inertia` starter kit to be configured internally.

This PR remove that `db` dependency.

I opened a [discussion](https://discord.com/channels/423256550564691970/1251612392669057075) in Discord.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
