### PR TITLE
fix: show current directory for empty relative cd in instructions

### DIFF
--- a/commands/main.ts
+++ b/commands/main.ts
@@ -249,10 +249,16 @@ export class CreateNewApp extends BaseCommand {
   #printSuccessMessage() {
     this.logger.log('')
 
-    this.ui
+    let instructions = this.ui
       .instructions()
       .heading('Your AdonisJS project has been created successfully!')
-      .add(this.colors.cyan('cd ' + (relative(cwd(), this.destination) || '.')))
+
+    const destRelativePath = relative(cwd(), this.destination)
+    if (destRelativePath !== '') {
+      instructions.add(this.colors.cyan(`cd ${destRelativePath}`))
+    }
+
+    instructions
       .add(this.colors.cyan(`${this.packageManager} run dev`))
       .add(this.colors.cyan('Open http://localhost:3333'))
       .add('')

--- a/commands/main.ts
+++ b/commands/main.ts
@@ -252,7 +252,7 @@ export class CreateNewApp extends BaseCommand {
     this.ui
       .instructions()
       .heading('Your AdonisJS project has been created successfully!')
-      .add(this.colors.cyan('cd ' + relative(cwd(), this.destination)))
+      .add(this.colors.cyan('cd ' + (relative(cwd(), this.destination) || '.')))
       .add(this.colors.cyan(`${this.packageManager} run dev`))
       .add(this.colors.cyan('Open http://localhost:3333'))
       .add('')


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Fixes https://github.com/adonisjs/create-adonisjs/issues/14

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If the relative path from the `cwd` and the `destination` is empty, e.g. the user is already in the destination directory, show `cd .` so that a user actually _doing that line of instructions_ doesn't take them to their home dir.

Could alternatively omit that instruction line entirely, but I opted for the smallest change possible here.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. **--> N/A**

**Demo**

<img width="765" height="921" alt="screenshot-2026-04-25_16-46-36" src="https://github.com/user-attachments/assets/fa63f80c-1d58-4fc8-b915-1b5a8ad28a83" />

